### PR TITLE
Correctly checking if JVM is already started

### DIFF
--- a/HeidelTime/__init__.py
+++ b/HeidelTime/__init__.py
@@ -1,7 +1,7 @@
 import jpype
 
 # start the JVM
-if jpype.isJVMStarted() is not 1:
+if not jpype.isJVMStarted():
 	jar = "HeidelTime/de.unihd.dbs.heideltime.standalone.jar"
 	jpype.startJVM(jpype.getDefaultJVMPath(), "-ea", "-Djava.class.path=%s" % jar)
 


### PR DESCRIPTION
"is not 1" did not properly work when the JVM is already started. WIth this small fix, the line works as intented.